### PR TITLE
Fix typo with Silver Eagle

### DIFF
--- a/Systems/silver-eagle-fdm.xml
+++ b/Systems/silver-eagle-fdm.xml
@@ -1070,7 +1070,7 @@
 	<system file="gear"/>
 	<system file="flaps"/>
 	
-	<fllight_control file="Systems/fdm-fcs.xml"/>
+	<flight_control file="Systems/fdm-fcs.xml"/>
 	
 	<aerodynamics file="Systems/fdm-aerodynamics.xml"/>
 	


### PR DESCRIPTION
On the Silver Eagle, this fixes the error of:
`FGPropertyValue::GetValue() The property fcs/aileron-pos-rad does not exist.`
And allows the plane to actually run.
